### PR TITLE
Only 'controller' and 'action' should get trailing dash.

### DIFF
--- a/LowercaseDashedRouting/LowercaseDashedRoute.cs
+++ b/LowercaseDashedRouting/LowercaseDashedRoute.cs
@@ -109,29 +109,18 @@ namespace LowercaseDashedRouting
 
 		public override VirtualPathData GetVirtualPath(RequestContext requestContext, RouteValueDictionary values)
 		{
-			VirtualPathData path = base.GetVirtualPath(requestContext, values);
-
-			if (path != null)
+			var action = values["action"] as string;
+			var controller = values["controller"] as string;
+			if (!string.IsNullOrEmpty(action))
 			{
-				string virtualPath = path.VirtualPath;
-				var lastIndexOf = virtualPath.LastIndexOf("?", System.StringComparison.InvariantCulture);
-
-				if (lastIndexOf != 0)
-				{
-					if (lastIndexOf > 0)
-					{
-						string leftPart = AddDashesBeforeCapitals(virtualPath.Substring(0, lastIndexOf)).ToLowerInvariant();
-						string queryPart = virtualPath.Substring(lastIndexOf);
-						path.VirtualPath = leftPart + queryPart;
-					}
-					else
-					{
-						path.VirtualPath = AddDashesBeforeCapitals(path.VirtualPath).ToLowerInvariant();
-					}
-				}
+				values["action"] = AddDashesBeforeCapitals(action).ToLowerInvariant();
 			}
 
-			return path;
+			if (!string.IsNullOrEmpty(controller))
+			{
+				values["controller"] = AddDashesBeforeCapitals(controller).ToLowerInvariant();
+			}
+			return base.GetVirtualPath(requestContext, values);
 		}
 
 		/// <summary>
@@ -142,9 +131,6 @@ namespace LowercaseDashedRouting
 		/// <returns>dashed text</returns>
 		protected static string AddDashesBeforeCapitals(string text)
 		{
-			if (string.IsNullOrWhiteSpace(text))
-				return string.Empty;
-
 			var newText = new StringBuilder(text.Length * 2);
 			newText.Append(text[0]);
 

--- a/LowercaseDashedRouting/Properties/AssemblyInfo.cs
+++ b/LowercaseDashedRouting/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]


### PR DESCRIPTION
In GetVirtualPath all of the parameters get trailing dash which is not good, the bad part is that they don't get undashed in DashedRouteHandler.
This is fixed now.
